### PR TITLE
Tadzik contacts: Make tests pass

### DIFF
--- a/src/app/compose/recipients.service.spec.ts
+++ b/src/app/compose/recipients.service.spec.ts
@@ -101,7 +101,7 @@ export class RunboxWebMailAPIMock {
                 nick: 'test2',
                 first_name: 'firstname2',
                 last_name: 'lastname2',
-                email: 'test2@example.com'
+                emails: [{ value: 'test2@example.com'} , {value: 'test4@example.com'}]
             })
         ]);
     }
@@ -131,7 +131,7 @@ describe('RecipientsService', () => {
         expect(window['termlistresult'].length).toBe(5);
         expect(window['termlistresult'].find(r => r === '"TESTINGPERSON" <test@example.com>')).toBeTruthy();
 
-        expect(recipients.length).toBe(3);
+        expect(recipients.length).toBe(4);
         expect(recipients.find(r => r.indexOf('test@example.com') > -1)).toBe('"firstname lastname" <test@example.com>');
         expect(recipients.find(r => r.indexOf('test2@example.com') > -1)).toBe('"firstname2 lastname2" <test2@example.com>');
         expect(recipients.find(r => r.indexOf('test5@example.com') > -1)).toBe('"TEST5" <test5@example.com>');

--- a/src/app/compose/recipients.service.ts
+++ b/src/app/compose/recipients.service.ts
@@ -53,10 +53,18 @@ export class RecipientsService {
 
             rmmapi.getAllContacts().subscribe(contacts => {
                 contacts.forEach(contact => {
-                    contact.emails.forEach(email => {
-                        const recipientString = `"${contact.full_name()}" <${email.value}>`;
-                        recipientsMap[email.value] = recipientString;
-                    });
+                    if (contact.emails) {
+                        // handle multiple email addresses per contact
+                        contact.emails.forEach(email => {
+                            const recipientString = `"${contact.full_name()}" <${email.value}>`;
+                            recipientsMap[email.value] = recipientString;
+                        });
+                    }
+                    if (contact.email) {
+                        // only one email address for contact (legacy)
+                        const recipientString = `"${contact.full_name()}" <${contact.email}>`;
+                        recipientsMap[contact.email] = recipientString;
+                    }
                 });
 
                 this.recipients.next(Object.keys(recipientsMap).map(mailaddr => recipientsMap[mailaddr]));

--- a/src/app/contacts-app/contact-details/contact-details.component.spec.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.spec.ts
@@ -23,6 +23,9 @@ import { ContactDetailsComponent } from './contact-details.component';
 import { ContactsAppModule } from '../contacts-app.module';
 import { RunboxWebmailAPI } from '../../rmmapi/rbwebmail';
 import { Router } from '@angular/router';
+import { MatDialogModule } from '@angular/material';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
 describe('ContactDetailsComponent', () => {
   let component: ContactDetailsComponent;
@@ -30,10 +33,15 @@ describe('ContactDetailsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ ContactsAppModule ],
+      imports: [ ContactsAppModule,
+          MatDialogModule,
+          RouterTestingModule.withRoutes([]) ],
       providers: [
-        { provide: RunboxWebmailAPI, useValue: {}},
-        { provide: Router, useValue: {}}
+        { provide: RunboxWebmailAPI, useValue: {
+          // Mocking empty responses from RMMAPI
+          getAllContacts: () => of([]),
+          getContactsSettings: () => of({})
+        }},
       ]
     })
     .compileComponents();

--- a/src/app/contacts-app/contact-details/contact-details.component.ts
+++ b/src/app/contacts-app/contact-details/contact-details.component.ts
@@ -202,7 +202,7 @@ export class ContactDetailsComponent {
         const return_url = '/contacts/' + this.contact.id;
         window.open(
             '/mail/addresses_contacts?edit=1' +
-            '&cid=' + this.contact.id.substr(4) +
+            '&cid=' + (typeof this.contact.id === 'string' ? this.contact.id.substr(4) : this.contact.id) +
             '&return_url=' + return_url,
             '_blank'
         );

--- a/src/app/contacts-app/contact.ts
+++ b/src/app/contacts-app/contact.ts
@@ -51,7 +51,7 @@ export class Address {
 }
 
 export class Contact {
-    id:         string;
+    id:         string | number;
 
     nickname:   string;
     first_name: string;
@@ -62,6 +62,7 @@ export class Contact {
     department: string;
     categories: string[];
 
+    email?: string; // Compatible with old api
     emails:     Email[]    = [];
     addresses:  Address[]  = [];
     urls:       URI[]      = [];
@@ -76,7 +77,7 @@ export class Contact {
             this[key] = properties[key];
         }
 
-        if (this.id && this.id.substr(0, 4) === 'RMM-') {
+        if (typeof this.id === 'string' && this.id.substr(0, 4) === 'RMM-') {
             this.rmm_backed = true;
         }
     }

--- a/src/app/contacts-app/contacts-app.component.html
+++ b/src/app/contacts-app/contacts-app.component.html
@@ -1,5 +1,3 @@
-<rmm-headertoolbar name="headertoolbar"></rmm-headertoolbar>
-
 <mat-sidenav-container autosize>
     <mat-sidenav #sidemenu mode="side" opened>
         <mat-nav-list dense>

--- a/src/app/contacts-app/contacts-app.module.ts
+++ b/src/app/contacts-app/contacts-app.module.ts
@@ -22,9 +22,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MenuModule } from '../menu/menu.module';
-import { RouterModule, Routes, RouteReuseStrategy } from '@angular/router';
-
-import { HeaderToolbarComponent } from '../menu/headertoolbar.component';
+import { RouterModule, RouteReuseStrategy } from '@angular/router';
 
 import {
   MatButtonModule,
@@ -43,6 +41,8 @@ import { ContactsSettingsComponent } from './contacts-settings.component';
 import { FormArrayEditorComponent } from './contact-details/formarray-editor.component';
 import { ContactsService } from './contacts.service';
 import { RMMRouteReuseStrategy } from './routereusestrategy';
+import { RMMAuthGuardService } from '../rmmapi/rmmauthguard.service';
+import { HeaderToolbarComponent } from '../menu/headertoolbar.component';
 
 @NgModule({
   declarations: [
@@ -67,22 +67,30 @@ import { RMMRouteReuseStrategy } from './routereusestrategy';
     ReactiveFormsModule,
     RouterModule.forChild([
       {
-        path: '', outlet: 'headertoolbar',
-        component: HeaderToolbarComponent
-      },
-      { path: 'contacts', component: ContactsAppComponent,
+        path: 'contacts',
+        canActivateChild: [RMMAuthGuardService],
         children: [
-         {
-            path: 'settings',
-            component: ContactsSettingsComponent,
-         },
-         {
-            path: ':id',
-            component: ContactDetailsComponent,
-            runGuardsAndResolvers: 'always'
-         }
+          {
+            path: '', outlet: 'headertoolbar',
+            component: HeaderToolbarComponent
+          },
+          {
+            path: '',
+            component: ContactsAppComponent,
+            children: [
+              {
+                  path: 'settings',
+                  component: ContactsSettingsComponent,
+              },
+              {
+                  path: ':id',
+                  component: ContactDetailsComponent,
+                  runGuardsAndResolvers: 'always'
+              }
+            ]
+          }
         ]
-      },
+      }
     ])
   ],
   providers: [


### PR DESCRIPTION
@tadzik Did a few things to make tests pass. But I'm still not able to see the contacts with the current production server REST API - which is maybe the purpose? In that case integration with compose and also its tests needs to be rewritten to work with the new API.

- fixed routing to not show header toolbar in login screen
- support both legacy api with one email addr per contact and new
with multiple email addresses per contact
- support both numeric and string contact id